### PR TITLE
Add CoreMark flow and configurable BEEBS RTL runner

### DIFF
--- a/tests/external_kernels/README.md
+++ b/tests/external_kernels/README.md
@@ -32,12 +32,45 @@ translates the upstream build artifacts into our Spike/ZeroNyte signature flow.
 
 ```bash
 tests/external_kernels/run_beebs.sh --benchmark cnt
+tests/external_kernels/run_beebs.sh --benchmark cnt --processor tetranyte --thread-mask 0x1
 ```
 
 The script applies the Zeronyte signature patch if needed, configures BEEBS for
 riscv32 (ri5cy chip, generic board), builds the requested benchmark, and runs
-Spike and ZeroNyte back-to-back. Artifacts land under
-`tests/output/external/beebs/<benchmark>`.
+Spike and the selected RTL core back-to-back (ZeroNyte by default). For the
+barrel-threaded TetraNyte core the runner automatically relaxes the max-cycle
+limit (4x the ZeroNyte default) and you can optionally pass `--thread-mask`
+to experiment with different thread enables. Artifacts land under
+`tests/output/external/beebs/<benchmark>` with individual logs and signatures
+per processor.
+
+### CoreMark workflow
+
+- Clone CoreMark via `tests/external_kernels/clone_all.sh` which places the
+  repository under `../external-kernels/coremark`.
+- Run `tests/external_kernels/run_coremark.sh` to build and execute the bare
+  metal port for Spike and the RTL cores. Example invocations:
+
+```bash
+# Single-threaded TetraNyte run (default thread 0)
+tests/external_kernels/run_coremark.sh --iterations 1 --processor tetranyte
+
+# Sweep all four hardware threads sequentially
+tests/external_kernels/run_coremark.sh --iterations 1 --processor tetranyte --all-threads
+
+# Run on ZeroNyte instead of TetraNyte
+tests/external_kernels/run_coremark.sh --processor zeronyte --max-cycles 5000000
+```
+
+The script copies the maintained `coremark_port` into the external clone,
+builds with the RV32 bare-metal toolchain, captures a Spike reference
+signature, and then runs the requested RTL simulator(s). Each TetraNyte run is
+rebuilt with a `COREMARK_THREAD_LABEL` tag so the four hardware contexts
+produce four distinct signatures. You can either pick a specific
+`--thread-mask` (e.g. `0x2` for thread 1) or pass `--all-threads` to iterate
+over masks `0x1`, `0x2`, `0x4`, and `0x8` sequentially; each iteration stores
+its own Spike and RTL logs/signatures under
+`tests/output/external/coremark/<label>/`.
 
 ## Cloning helper
 

--- a/tests/external_kernels/coremark_port/core_portme.c
+++ b/tests/external_kernels/coremark_port/core_portme.c
@@ -1,0 +1,148 @@
+#include "coremark.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define COREMARK_SIGNATURE_WORDS 32u
+#ifndef COREMARK_THREAD_LABEL
+#define COREMARK_THREAD_LABEL 0u
+#endif
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+__attribute__((section(".signature")))
+volatile uint32_t coremark_signature_buffer[COREMARK_SIGNATURE_WORDS];
+
+__asm__(".globl begin_signature\n"
+        "begin_signature = coremark_signature_buffer\n");
+__asm__(".globl end_signature\n"
+        "end_signature = coremark_signature_buffer + "
+        STR(COREMARK_SIGNATURE_WORDS * 4) "\n");
+
+extern volatile uint64_t tohost;
+extern volatile uint64_t fromhost;
+
+#if VALIDATION_RUN
+volatile ee_s32 seed1_volatile = 0x3415;
+volatile ee_s32 seed2_volatile = 0x3415;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PERFORMANCE_RUN
+volatile ee_s32 seed1_volatile = 0x0;
+volatile ee_s32 seed2_volatile = 0x0;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PROFILE_RUN
+volatile ee_s32 seed1_volatile = 0x8;
+volatile ee_s32 seed2_volatile = 0x8;
+volatile ee_s32 seed3_volatile = 0x8;
+#endif
+volatile ee_s32 seed4_volatile = ITERATIONS;
+volatile ee_s32 seed5_volatile = 0;
+
+static CORE_TICKS cycle_start;
+static CORE_TICKS cycle_stop;
+static CORE_TICKS last_ticks;
+static core_results *global_results;
+static ee_size_t heap_offset;
+
+#define COREMARK_HEAP_SIZE (64u * 1024u)
+static uint8_t coremark_heap[COREMARK_HEAP_SIZE];
+
+ee_u32 default_num_contexts = 1;
+
+static inline CORE_TICKS read_cycle(void) {
+  static CORE_TICKS synthetic_ticks = 0;
+  return ++synthetic_ticks;
+}
+
+static inline core_results *port_to_results(core_portable *p) {
+  if (p == NULL) {
+    return NULL;
+  }
+  uintptr_t base = (uintptr_t)p - offsetof(core_results, port);
+  return (core_results *)base;
+}
+
+static void record_signature(const core_results *res) {
+  if (!res) {
+    return;
+  }
+  coremark_signature_buffer[0] = (uint32_t)res->crc;
+  coremark_signature_buffer[1] = (uint32_t)res->crclist;
+  coremark_signature_buffer[2] = (uint32_t)res->crcmatrix;
+  coremark_signature_buffer[3] = (uint32_t)res->crcstate;
+  coremark_signature_buffer[4] = (uint32_t)res->iterations;
+  coremark_signature_buffer[5] = (uint32_t)res->execs;
+  coremark_signature_buffer[6] = (uint32_t)(uint16_t)res->seed1;
+  coremark_signature_buffer[7] = (uint32_t)(uint16_t)res->seed2;
+  coremark_signature_buffer[8] = (uint32_t)(uint16_t)res->seed3;
+  coremark_signature_buffer[9] = (uint32_t)res->size;
+  coremark_signature_buffer[10] = (uint32_t)res->err;
+  coremark_signature_buffer[11] = last_ticks;
+  coremark_signature_buffer[12] = 0xC01ECAFEu;
+  coremark_signature_buffer[13] = COREMARK_THREAD_LABEL;
+  coremark_signature_buffer[14] = (uint32_t)res->err;
+}
+
+void start_time(void) {
+  cycle_start = read_cycle();
+}
+
+void stop_time(void) {
+  cycle_stop = read_cycle();
+  last_ticks = cycle_stop - cycle_start;
+}
+
+CORE_TICKS get_time(void) {
+  return cycle_stop - cycle_start;
+}
+
+secs_ret time_in_secs(CORE_TICKS ticks) {
+  return (secs_ret)ticks;
+}
+
+void portable_init(core_portable *p, int *argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+  if (p) {
+    p->portable_id = 1;
+    global_results = port_to_results(p);
+  }
+  heap_offset = 0;
+}
+
+void portable_fini(core_portable *p) {
+  (void)p;
+  if (global_results) {
+    record_signature(global_results);
+    if (global_results->err != 0) {
+      coremark_signature_buffer[15] =
+          0xBAD00000u | ((uint32_t)global_results->err & 0xFFFFu);
+    } else {
+      coremark_signature_buffer[15] = 0;
+    }
+  }
+  tohost = 1;
+}
+
+void *portable_malloc(ee_size_t size) {
+  const ee_size_t align = 8u;
+  ee_size_t aligned_offset = (heap_offset + (align - 1u)) & ~(align - 1u);
+  if (size == 0 || aligned_offset + size > COREMARK_HEAP_SIZE) {
+    return NULL;
+  }
+  void *ptr = &coremark_heap[aligned_offset];
+  heap_offset = aligned_offset + size;
+  return ptr;
+}
+
+void portable_free(void *p) {
+  (void)p;
+}
+
+int ee_printf(const char *fmt, ...) {
+  (void)fmt;
+  return 0;
+}

--- a/tests/external_kernels/coremark_port/core_portme.h
+++ b/tests/external_kernels/coremark_port/core_portme.h
@@ -1,0 +1,65 @@
+#ifndef CORE_PORTME_H
+#define CORE_PORTME_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Platform capabilities */
+#define HAS_FLOAT   0
+#define HAS_TIME_H  0
+#define USE_CLOCK   0
+#define HAS_STDIO   0
+#define HAS_PRINTF  0
+
+/* Execution model */
+#define MEM_METHOD      MEM_MALLOC
+#define SEED_METHOD     SEED_VOLATILE
+#define MULTITHREAD     1
+#define MAIN_HAS_NOARGC 1
+#define MAIN_HAS_NORETURN 0
+
+#ifndef TOTAL_DATA_SIZE
+#define TOTAL_DATA_SIZE (2 * 1000)
+#endif
+
+#ifndef COMPILER_VERSION
+#ifdef __GNUC__
+#define COMPILER_VERSION "GCC " __VERSION__
+#else
+#define COMPILER_VERSION "unknown"
+#endif
+#endif
+
+#ifndef COMPILER_FLAGS
+#define COMPILER_FLAGS "-march=rv32i_zicsr -mabi=ilp32 -O2 -ffreestanding"
+#endif
+
+#ifndef MEM_LOCATION
+#define MEM_LOCATION "FLASH"
+#endif
+
+/* CoreMark required typedefs */
+typedef signed short   ee_s16;
+typedef unsigned short ee_u16;
+typedef signed int     ee_s32;
+typedef unsigned int   ee_u32;
+typedef unsigned char  ee_u8;
+typedef unsigned int   ee_ptr_int;
+typedef size_t         ee_size_t;
+typedef ee_u32         CORE_TICKS;
+
+#define align_mem(x) (void *)(4 + (((ee_ptr_int)(x) - 1) & ~3))
+
+typedef struct CORE_PORTABLE_S {
+  ee_u32 portable_id;
+} core_portable;
+
+extern ee_u32 default_num_contexts;
+
+void portable_init(core_portable *p, int *argc, char *argv[]);
+void portable_fini(core_portable *p);
+void *portable_malloc(ee_size_t size);
+void portable_free(void *p);
+int ee_printf(const char *fmt, ...);
+
+#endif  /* CORE_PORTME_H */

--- a/tests/external_kernels/coremark_port/core_portme.mak
+++ b/tests/external_kernels/coremark_port/core_portme.mak
@@ -1,0 +1,41 @@
+RISCV_PREFIX ?= /opt/riscv/bin/riscv64-unknown-elf-
+CC := $(RISCV_PREFIX)gcc
+AR := $(RISCV_PREFIX)ar
+LD := $(CC)
+
+OUTFLAG = -o
+EXE =
+OEXT = .o
+MKDIR = mkdir -p
+
+PORT_SRCS = $(PORT_DIR)/core_portme.c $(PORT_DIR)/crt0.S
+PORT_CFLAGS = \
+  -march=rv32i_zicsr \
+  -mabi=ilp32 \
+  -mcmodel=medany \
+  -O2 \
+  -ffreestanding \
+  -fno-builtin \
+  -fdata-sections \
+  -ffunction-sections \
+  -g \
+  -static \
+  -nostdlib \
+  -nostartfiles \
+  -Wall \
+  -Wextra \
+  -I$(PORT_DIR)
+FLAGS_STR = "-march=rv32i_zicsr -O2 -ffreestanding"
+CFLAGS = $(PORT_CFLAGS) -I. -DFLAGS_STR=\"$(FLAGS_STR)\"
+LFLAGS_END = \
+  -Wl,-T,$(PORT_DIR)/link.ld \
+  -Wl,-Map=$(OPATH)coremark.map \
+  -Wl,--gc-sections \
+  -nostdlib \
+  -nostartfiles \
+  -static \
+  -lgcc
+
+LOAD = @:
+RUN = @:
+PORT_CLEAN = $(OPATH)coremark.map

--- a/tests/external_kernels/coremark_port/crt0.S
+++ b/tests/external_kernels/coremark_port/crt0.S
@@ -1,0 +1,44 @@
+.section .text.init
+.globl _start
+_start:
+  la sp, _stack_top
+  la t0, trap_vector
+  csrw mtvec, t0
+  call main
+
+  li t1, 1
+  beqz a0, 1f
+  mv t1, a0
+1:
+  la t0, tohost
+  sw t1, 0(t0)
+2:
+  j 2b
+
+.section .tohost, "aw", @progbits
+.align 8
+.globl tohost
+tohost:
+  .dword 0
+
+.align 4
+trap_vector:
+  csrr t2, mcause
+  csrr t3, mepc
+  la t4, coremark_signature_buffer
+  li t5, 31
+  slli t5, t5, 2
+  add t4, t4, t5
+  sw t2, 0(t4)
+  addi t4, t4, -4
+  sw t3, 0(t4)
+  la t0, tohost
+  li t1, 1
+  sw t1, 0(t0)
+1:
+  j 1b
+
+.align 8
+.globl fromhost
+fromhost:
+  .dword 0

--- a/tests/external_kernels/coremark_port/link.ld
+++ b/tests/external_kernels/coremark_port/link.ld
@@ -1,0 +1,32 @@
+OUTPUT_ARCH("riscv")
+ENTRY(_start)
+
+SECTIONS
+{
+  . = 0x80000000;
+  .text.init : { *(.text.init) }
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+  . = ALIGN(0x1000);
+  .text : { *(.text .text.*) }
+  .rodata : { *(.rodata .rodata.*) }
+  . = ALIGN(0x1000);
+  .data : { *(.data .data.*) }
+  .sdata : { *(.sdata .sdata.*) }
+  .bss : {
+    *(.sbss .sbss.*)
+    *(.bss .bss.*)
+    *(COMMON)
+  }
+
+  . = ALIGN(16);
+  .signature : { *(.signature) }
+
+  . = ALIGN(16);
+  .stack (NOLOAD) : {
+    . = . + 0x20000;
+    _stack_top = .;
+  }
+
+  _end = .;
+}

--- a/tests/external_kernels/run_beebs.sh
+++ b/tests/external_kernels/run_beebs.sh
@@ -20,23 +20,30 @@ ISA=${ISA:-rv32i}
 
 usage() {
   cat <<USAGE
-Usage: $(basename "$0") --benchmark <name> [--out-dir <path>] [--max-cycles <count>] [--force-configure]
+Usage: $(basename "$0") --benchmark <name> [--out-dir <path>] [--max-cycles <count>] [--force-configure] [--processor <name>] [--thread-mask <mask>]
 
-Builds and runs the requested BEEBS benchmark using Spike (reference) and ZeroNyte RTL.
+Builds and runs the requested BEEBS benchmark using Spike (reference) and the selected RTL core.
 Requires the BEEBS repository at $BEEBS_ROOT (clone via tests/external_kernels/clone_all.sh).
 
 Options:
   --benchmark <name>   Benchmark directory under beebs/src (e.g. cnt, fir, qsort).
   --out-dir <path>     Output directory for artifacts (defaults to tests/output/external/beebs/<name>).
-  --max-cycles <n>     Cycle limit for zeronyte_sim (default: 1000000).
+  --max-cycles <n>     Cycle limit for the RTL simulator (default: 1000000).
   --force-configure    Re-run ./configure even if config.status exists.
+  --processor <name>   RTL simulator to use (zeronyte or tetranyte; default: zeronyte).
+  --thread-mask <mask> Thread enable bitmask for TetraNyte (e.g. 0x1 for thread0).
 USAGE
 }
 
 BENCH=""
 OUT_DIR=""
-MAX_CYCLES=1000000
+DEFAULT_MAX_CYCLES=1000000
+MAX_CYCLES=$DEFAULT_MAX_CYCLES
+MAX_CYCLES_OVERRIDDEN=0
+BENCH_CYCLE_OVERRIDE=0
 FORCE_CONFIGURE=0
+PROCESSOR="zeronyte"
+THREAD_MASK="${TETRANYTE_THREAD_MASK:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -50,11 +57,28 @@ while [[ $# -gt 0 ]]; do
       ;;
     --max-cycles)
       MAX_CYCLES="$2"
+      MAX_CYCLES_OVERRIDDEN=1
       shift 2
       ;;
     --force-configure)
       FORCE_CONFIGURE=1
       shift
+      ;;
+    --processor)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --processor requires an argument." >&2
+        exit 1
+      fi
+      PROCESSOR="$2"
+      shift 2
+      ;;
+    --thread-mask)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --thread-mask requires a value (e.g. 0x1)." >&2
+        exit 1
+      fi
+      THREAD_MASK="$2"
+      shift 2
       ;;
     --help|-h)
       usage
@@ -74,6 +98,19 @@ if [[ -z "$BENCH" ]]; then
   exit 1
 fi
 
+if [[ "$MAX_CYCLES_OVERRIDDEN" -eq 0 ]]; then
+  case "$BENCH" in
+    whetstone)
+      MAX_CYCLES=30000000
+      BENCH_CYCLE_OVERRIDE=1
+      echo "[beebs] Applying benchmark-specific max cycle limit: $MAX_CYCLES"
+      ;;
+    *)
+      MAX_CYCLES=$DEFAULT_MAX_CYCLES
+      ;;
+  esac
+fi
+
 if [[ ! -d "$BEEBS_ROOT" ]]; then
   echo "BEEBS repository not found at $BEEBS_ROOT. Run tests/external_kernels/clone_all.sh first." >&2
   exit 1
@@ -82,6 +119,38 @@ fi
 if [[ ! -f "$PATCH_FILE" ]]; then
   echo "Missing patch file: $PATCH_FILE" >&2
   exit 1
+fi
+
+SIM_NAME=""
+SIM_BUILD_SCRIPT=""
+SIM_BINARY=""
+
+case "$PROCESSOR" in
+  zeronyte)
+    SIM_NAME="ZeroNyte"
+    SIM_BUILD_SCRIPT="$REPO_ROOT/tests/sim/build_zeronyte_sim.sh"
+    SIM_BINARY="$REPO_ROOT/tests/sim/build/zeronyte_sim"
+    ;;
+  tetranyte)
+    SIM_NAME="TetraNyte"
+    SIM_BUILD_SCRIPT="$REPO_ROOT/tests/sim/build_tetranyte_sim.sh"
+    SIM_BINARY="$REPO_ROOT/tests/sim/build/tetranyte_sim"
+    ;;
+  *)
+    echo "Unsupported processor: $PROCESSOR" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -x "$SIM_BUILD_SCRIPT" ]]; then
+  echo "Simulation build script not found for $PROCESSOR: $SIM_BUILD_SCRIPT" >&2
+  exit 1
+fi
+
+if [[ "$MAX_CYCLES_OVERRIDDEN" -eq 0 && "$BENCH_CYCLE_OVERRIDE" -eq 0 && "$PROCESSOR" == "tetranyte" ]]; then
+  TETRANYTE_CYCLE_MULTIPLIER=4
+  MAX_CYCLES=$((DEFAULT_MAX_CYCLES * TETRANYTE_CYCLE_MULTIPLIER))
+  echo "[beebs] Applying tetranyte-specific max cycle limit: $MAX_CYCLES"
 fi
 
 ensure_patch_applied() {
@@ -161,8 +230,8 @@ mkdir -p "$OUT_DIR"
 
 SPIKE_SIG="$OUT_DIR/spike.signature"
 SPIKE_LOG="$OUT_DIR/spike.log"
-RTL_SIG="$OUT_DIR/zeronyte.signature"
-RTL_LOG="$OUT_DIR/zeronyte.log"
+RTL_SIG="$OUT_DIR/${PROCESSOR}.signature"
+RTL_LOG="$OUT_DIR/${PROCESSOR}.log"
 
 echo "[beebs] Running Spike reference..."
 "$SPIKE_BIN" \
@@ -172,17 +241,28 @@ echo "[beebs] Running Spike reference..."
   "$ELF_PATH" \
   >"$SPIKE_LOG" 2>&1
 
-ZERONYTE_SIM="$REPO_ROOT/tests/sim/build/zeronyte_sim"
-if [[ ! -x "$ZERONYTE_SIM" ]]; then
-  "$REPO_ROOT/tests/sim/build_zeronyte_sim.sh"
+if [[ ! -x "$SIM_BINARY" ]]; then
+  "$SIM_BUILD_SCRIPT"
 fi
 
-echo "[beebs] Running ZeroNyte RTL..."
-"$ZERONYTE_SIM" \
-  --elf "$ELF_PATH" \
-  --signature "$RTL_SIG" \
-  --log "$RTL_LOG" \
+if [[ ! -x "$SIM_BINARY" ]]; then
+  echo "Simulator binary not found at $SIM_BINARY" >&2
+  exit 1
+fi
+
+SIM_CMD=(
+  "$SIM_BINARY"
+  --elf "$ELF_PATH"
+  --signature "$RTL_SIG"
+  --log "$RTL_LOG"
   --max-cycles "$MAX_CYCLES"
+)
+if [[ "$PROCESSOR" == "tetranyte" && -n "$THREAD_MASK" ]]; then
+  SIM_CMD+=(--thread-mask "$THREAD_MASK")
+fi
+
+echo "[beebs] Running $SIM_NAME RTL..."
+"${SIM_CMD[@]}"
 
 echo "[beebs] Comparing signatures..."
 if cmp -s "$SPIKE_SIG" "$RTL_SIG"; then

--- a/tests/external_kernels/run_coremark.sh
+++ b/tests/external_kernels/run_coremark.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+COREMARK_ROOT=${COREMARK_ROOT:-"$REPO_ROOT/../external-kernels/coremark"}
+PORT_NAME="kryptonnyte"
+PORT_SRC="$SCRIPT_DIR/coremark_port"
+PORT_DST="$COREMARK_ROOT/$PORT_NAME"
+BUILD_DIR="$COREMARK_ROOT/build/$PORT_NAME"
+DEFAULT_OUT_DIR="$REPO_ROOT/tests/output/external/coremark"
+
+RISCV_PREFIX=${RISCV_PREFIX:-/opt/riscv/bin/riscv64-unknown-elf-}
+SPIKE_BIN=${SPIKE_BIN:-/opt/riscv/bin/spike}
+ISA=${ISA:-rv32i}
+
+ITERATIONS=1
+OUT_DIR=""
+MAX_CYCLES=20000000
+PROCESSOR="tetranyte"
+THREAD_MASK=""
+RUN_ALL_THREADS=0
+SKIP_SPIKE=0
+FORCE_REBUILD=0
+COREMARK_XCFLAGS=${COREMARK_XCFLAGS:-"-DPERFORMANCE_RUN=1"}
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Builds CoreMark for the KryptoNyte cores and runs Spike + RTL to compare signatures.
+
+Options:
+  --iterations <n>     CoreMark iterations (default: $ITERATIONS)
+  --processor <name>   zeronyte or tetranyte (default: tetranyte)
+  --thread-mask <mask> Enable a specific TetraNyte thread mask (default: 0x1)
+  --all-threads        Run TetraNyte 4 times (thread0..thread3)
+  --max-cycles <n>     RTL max cycles (default: $MAX_CYCLES)
+  --out-dir <path>     Output root (default: $DEFAULT_OUT_DIR)
+  --skip-spike         Skip Spike reference run
+  --force-rebuild      Delete the CoreMark build directory before compiling
+  --xcflags <flags>    Extra CoreMark XCFLAGS string (default: "$COREMARK_XCFLAGS")
+  --help               Show this help message
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --iterations)
+      ITERATIONS="$2"; shift 2;;
+    --processor)
+      PROCESSOR="$2"; shift 2;;
+    --thread-mask)
+      THREAD_MASK="$2"; shift 2;;
+    --all-threads)
+      RUN_ALL_THREADS=1; shift;;
+    --max-cycles)
+      MAX_CYCLES="$2"; shift 2;;
+    --out-dir)
+      OUT_DIR="$2"; shift 2;;
+    --skip-spike)
+      SKIP_SPIKE=1; shift;;
+    --force-rebuild)
+      FORCE_REBUILD=1; shift;;
+    --xcflags)
+      COREMARK_XCFLAGS="$2"; shift 2;;
+    --help|-h)
+      usage; exit 0;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1;;
+  esac
+done
+
+if [[ ! -d "$COREMARK_ROOT" ]]; then
+  echo "CoreMark repo not found at $COREMARK_ROOT. Run tests/external_kernels/clone_all.sh first." >&2
+  exit 1
+fi
+
+if [[ ! -d "$PORT_SRC" ]]; then
+  echo "Missing port directory: $PORT_SRC" >&2
+  exit 1
+fi
+
+if [[ "$RUN_ALL_THREADS" -eq 1 && -n "$THREAD_MASK" ]]; then
+  echo "Cannot combine --all-threads with --thread-mask." >&2
+  exit 1
+fi
+
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="$DEFAULT_OUT_DIR"
+fi
+mkdir -p "$OUT_DIR"
+
+if command -v rsync >/dev/null 2>&1; then
+  rsync -a --delete "$PORT_SRC/" "$PORT_DST/"
+else
+  rm -rf "$PORT_DST"
+  mkdir -p "$PORT_DST"
+  cp -a "$PORT_SRC/." "$PORT_DST/"
+fi
+
+declare -A SIM_BUILD
+SIM_BUILD[zeronyte]="$REPO_ROOT/tests/sim/build_zeronyte_sim.sh"
+SIM_BUILD[tetranyte]="$REPO_ROOT/tests/sim/build_tetranyte_sim.sh"
+
+declare -A SIM_BIN
+SIM_BIN[zeronyte]="$REPO_ROOT/tests/sim/build/zeronyte_sim"
+SIM_BIN[tetranyte]="$REPO_ROOT/tests/sim/build/tetranyte_sim"
+
+if [[ -z "${SIM_BUILD[$PROCESSOR]:-}" ]]; then
+  echo "Unsupported processor: $PROCESSOR" >&2
+  exit 1
+fi
+
+if [[ "$FORCE_REBUILD" -eq 1 ]]; then
+  rm -rf "$BUILD_DIR"
+fi
+
+build_coremark() {
+  local label="$1"
+  local tag="$2"
+  local build_subdir="$BUILD_DIR/$label"
+  local xcflags="$COREMARK_XCFLAGS"
+  if [[ -n "$tag" ]]; then
+    xcflags+=" -DCOREMARK_THREAD_LABEL=$tag"
+  fi
+  rm -rf "$build_subdir"
+  mkdir -p "$build_subdir"
+  echo "[coremark] Building CoreMark for $label (xcflags=$xcflags)..." >&2
+  make -C "$COREMARK_ROOT" \
+    PORT_DIR="$PORT_NAME" \
+    OPATH="$build_subdir/" \
+    ITERATIONS="$ITERATIONS" \
+    XCFLAGS="$xcflags" \
+    RISCV_PREFIX="$RISCV_PREFIX" \
+    REBUILD=1 \
+    compile >/dev/null
+  printf "%s" "$build_subdir/coremark"
+}
+
+run_label() {
+  local label="$1"
+  local mask="$2"
+  local tag="$3"
+  local elf_path
+  elf_path=$(build_coremark "$label" "$tag")
+  if [[ ! -f "$elf_path" ]]; then
+    echo "Failed to build coremark ELF at $elf_path" >&2
+    exit 1
+  fi
+  local run_dir="$OUT_DIR/$label"
+  mkdir -p "$run_dir"
+  local spike_sig="$run_dir/spike.signature"
+  local spike_log="$run_dir/spike.log"
+  if [[ "$SKIP_SPIKE" -eq 0 ]]; then
+    echo "[coremark] Running Spike reference for $label..."
+    "$SPIKE_BIN" --isa="$ISA" +signature="$spike_sig" +signature-granularity=4 "$elf_path" >"$spike_log" 2>&1
+  else
+    : >"$spike_sig"
+  fi
+
+  if [[ ! -x "${SIM_BIN[$PROCESSOR]}" ]]; then
+    "${SIM_BUILD[$PROCESSOR]}"
+  fi
+  if [[ ! -x "${SIM_BIN[$PROCESSOR]}" ]]; then
+    echo "Simulator binary missing: ${SIM_BIN[$PROCESSOR]}" >&2
+    exit 1
+  fi
+
+  local rtl_sig="$run_dir/${PROCESSOR}.signature"
+  local rtl_log="$run_dir/${PROCESSOR}.log"
+  local cmd=("${SIM_BIN[$PROCESSOR]}" --elf "$elf_path" --signature "$rtl_sig" --log "$rtl_log" --max-cycles "$MAX_CYCLES")
+  if [[ "$PROCESSOR" == "tetranyte" && -n "$mask" ]]; then
+    cmd+=(--thread-mask "$mask")
+  fi
+  echo "[coremark] Running $PROCESSOR (label=$label mask=${mask:-n/a})..."
+  "${cmd[@]}"
+
+  if [[ "$SKIP_SPIKE" -eq 0 ]]; then
+    if cmp -s "$spike_sig" "$rtl_sig"; then
+      echo "[coremark] PASS: signatures match for $label"
+    else
+      echo "[coremark] FAIL: signature mismatch for $label" >&2
+      diff -u "$spike_sig" "$rtl_sig" || true
+      exit 1
+    fi
+  else
+    echo "[coremark] Skipped signature comparison for $label"
+  fi
+}
+
+declare -a RUN_LABELS
+declare -a RUN_MASKS
+declare -a RUN_TAGS
+
+if [[ "$PROCESSOR" == "tetranyte" ]]; then
+  if [[ "$RUN_ALL_THREADS" -eq 1 ]]; then
+    RUN_LABELS=(thread0 thread1 thread2 thread3)
+    RUN_MASKS=(0x1 0x2 0x4 0x8)
+    RUN_TAGS=(1 2 4 8)
+  else
+    mask=${THREAD_MASK:-0x1}
+    RUN_LABELS=("mask_${mask}")
+    RUN_MASKS=("$mask")
+    RUN_TAGS=($((mask)))
+  fi
+else
+  RUN_LABELS=("${PROCESSOR}")
+  RUN_MASKS=("")
+  RUN_TAGS=("")
+fi
+
+for idx in "${!RUN_LABELS[@]}"; do
+  run_label "${RUN_LABELS[$idx]}" "${RUN_MASKS[$idx]}" "${RUN_TAGS[$idx]}"
+done
+
+echo "[coremark] Done. Artifacts in $OUT_DIR"

--- a/tests/sim/zeronyte_sim.cpp
+++ b/tests/sim/zeronyte_sim.cpp
@@ -1,6 +1,7 @@
 #include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -15,6 +16,9 @@ struct Options {
   std::string signature;
   std::string log;
   uint64_t max_cycles = 1000000;
+  uint64_t log_start_cycle = 0;
+  uint64_t log_stop_cycle = std::numeric_limits<uint64_t>::max();
+  bool log_debug_traces = false;
 };
 
 Options parseArgs(int argc, char** argv) {
@@ -29,12 +33,21 @@ Options parseArgs(int argc, char** argv) {
       opts.log = argv[++i];
     } else if (arg == "--max-cycles" && i + 1 < argc) {
       opts.max_cycles = std::stoull(argv[++i]);
+    } else if (arg == "--log-start-cycle" && i + 1 < argc) {
+      opts.log_start_cycle = std::stoull(argv[++i]);
+    } else if (arg == "--log-stop-cycle" && i + 1 < argc) {
+      opts.log_stop_cycle = std::stoull(argv[++i]);
+    } else if (arg == "--log-debug") {
+      opts.log_debug_traces = true;
     } else {
       throw std::invalid_argument("unknown or incomplete argument: " + arg);
     }
   }
   if (opts.elf.empty() || opts.signature.empty()) {
     throw std::invalid_argument("--elf and --signature are required");
+  }
+  if (opts.log_stop_cycle < opts.log_start_cycle) {
+    throw std::invalid_argument("--log-stop-cycle must be >= --log-start-cycle");
   }
   return opts;
 }
@@ -120,13 +133,32 @@ int main(int argc, char** argv) {
       }
     }
 
-    if (log.is_open()) {
+    if (log.is_open() && cycle >= options.log_start_cycle && cycle <= options.log_stop_cycle) {
       log << std::hex
           << "cycle=0x" << cycle
           << " pc=0x" << dut.io_pc_out
           << " instr=0x" << dut.io_instr_out
-          << " result=0x" << dut.io_result
-          << std::dec << '\n';
+          << " result=0x" << dut.io_result;
+
+      if (options.log_debug_traces) {
+        log << " aluA=0x" << dut.io_debug_aluA
+            << " aluB=0x" << dut.io_debug_aluB
+            << " aluOpcode=0x" << static_cast<uint64_t>(dut.io_debug_aluOpcode)
+            << " effAddr=0x" << dut.io_debug_effAddr
+            << " dmemAddr=0x" << dut.io_dmem_addr
+            << " dmemWData=0x" << dut.io_dmem_wdata
+            << " dmemWEn=" << (dut.io_dmem_wen ? 1 : 0)
+            << " storeData=0x" << dut.io_debug_memWriteData
+            << " storeMask=0x" << static_cast<uint64_t>(dut.io_debug_memWriteMask)
+            << " branchTaken=" << (dut.io_debug_branchTaken ? 1 : 0)
+            << " branchTarget=0x" << dut.io_debug_branchTarget
+            << " divActive=" << (dut.io_debug_divActive ? 1 : 0)
+            << " divDone=" << (dut.io_debug_divDone ? 1 : 0)
+            << " divDividend=0x" << dut.io_debug_divDividend
+            << " divDivisor=0x" << dut.io_debug_divDivisor;
+      }
+
+      log << std::dec << '\n';
     }
 
     if (completed) {


### PR DESCRIPTION

- Added CoreMark bare-metal port files under `tests/external_kernels/coremark_port/`.
- Added `tests/external_kernels/run_coremark.sh` for Spike + RTL execution, including TetraNyte per-thread runs.
- Extended `tests/external_kernels/run_beebs.sh` with `--processor` and optional `--thread-mask` support.
- Updated `tests/external_kernels/README.md` with CoreMark and updated BEEBS workflows.
- Updated `tests/sim/zeronyte_sim.cpp` logging to support cycle windows and optional debug-trace fields.